### PR TITLE
feat(conversion): implement tool-specific JSON-to-Markdown converters

### DIFF
--- a/tools/components/ToolRequestForm/ToolRequestForm.jsx
+++ b/tools/components/ToolRequestForm/ToolRequestForm.jsx
@@ -22,10 +22,18 @@ import { firestore } from '@/libs/redux/store';
 
 import { fetchToolHistory, actions as toolActions } from '@/tools/data';
 import { INPUT_TYPES } from '@/tools/libs/constants/inputs';
+import { EDIT_HISTORY_TYPES } from '@/tools/libs/constants/editor';
 import submitPrompt from '@/tools/libs/services/submitPrompt';
 import evaluateCondition from '@/tools/libs/utils/evaluateCondition';
+import { convertResponseToMarkdown } from '@/tools/libs/utils/markdownConverter';
 
-const { setCommunicatorLoading, setFormOpen, setResponse } = toolActions;
+const {
+  setCommunicatorLoading,
+  setFormOpen,
+  setResponse,
+  setMarkdownContent,
+  addStateToEditHistory,
+} = toolActions;
 
 const ToolRequestForm = (props) => {
   const { id, inputs } = props;
@@ -135,7 +143,17 @@ const ToolRequestForm = (props) => {
         dispatch
       );
 
+      const markdown = convertResponseToMarkdown(response, id);
+
       dispatch(setResponse(response));
+      dispatch(setMarkdownContent(markdown));
+      dispatch(
+        addStateToEditHistory({
+          content: markdown,
+          type: EDIT_HISTORY_TYPES.INITIAL,
+          timestamp: Date.now(),
+        })
+      );
       dispatch(setFormOpen(false));
       dispatch(setCommunicatorLoading(false));
       dispatch(fetchToolHistory({ firestore }));

--- a/tools/data/slices/toolsSlice.js
+++ b/tools/data/slices/toolsSlice.js
@@ -11,6 +11,10 @@ const toolsState = {
 const communicator = {
   prompt: null,
   response: null,
+  editorState: {
+    markdownContent: null,
+    editHistory: [],
+  },
   communicatorLoading: false,
   formOpen: true,
 };
@@ -37,6 +41,18 @@ const tools = createSlice({
     },
     setResponse: (state, action) => {
       state.response = action.payload;
+    },
+    setMarkdownContent: (state, action) => {
+      state.editorState.markdownContent = action.payload;
+    },
+    addStateToEditHistory: (state, action) => {
+      state.editorState.editHistory = [
+        ...state.editorState.editHistory,
+        action.payload,
+      ];
+      if (state.editorState.editHistory.length > 15) {
+        state.editorState.editHistory.shift();
+      }
     },
     setError: (state, action) => {
       state.error = action.payload;

--- a/tools/libs/constants/editor.js
+++ b/tools/libs/constants/editor.js
@@ -1,0 +1,6 @@
+export const EDIT_HISTORY_TYPES = {
+  INITIAL: 'initial',
+  AUTO_SAVE: 'auto-save',
+  MANUAL_SAVE: 'manual-save',
+  RESTORE: 'restore',
+};

--- a/tools/libs/utils/markdownConverter.js
+++ b/tools/libs/utils/markdownConverter.js
@@ -1,0 +1,171 @@
+import { TOOLS_ID } from '../constants/tools';
+
+const escapeMarkdown = (text) => {
+  if (typeof text !== 'string') return '';
+  return text.replace(/([*_#`[\]>\\])/g, '\\$1');
+};
+
+const convertQuizToMarkdown = (response) => {
+  if (!Array.isArray(response)) return '';
+
+  return response
+    .map((question, index) => {
+      const escapedQuestion = escapeMarkdown(question.question);
+      const questionText = `# ${index + 1}. ${escapedQuestion}\n`;
+      const choices = question.choices
+        .map(
+          (choice) =>
+            `&nbsp;&nbsp;${choice.key}. ${escapeMarkdown(choice.value)}`
+        )
+        .join('\n');
+      return `${questionText}${choices}`;
+    })
+    .join('\n\n');
+};
+
+const convertFlashcardsToMarkdown = (response) => {
+  if (!Array.isArray(response)) return '';
+
+  return response
+    .map((card) => {
+      const escapedDefinition = escapeMarkdown(card.definition);
+      return `### ${escapeMarkdown(card.concept)}\n${escapedDefinition}`;
+    })
+    .join('\n\n---\n\n');
+};
+
+const convertWorksheetToMarkdown = (response) => {
+  if (typeof response !== 'object') return '';
+
+  let markdown = '';
+  let questionNumber = 1;
+
+  // Multiple Choice Questions
+  if (response.multiple_choice_question) {
+    response.multiple_choice_question.forEach((q) => {
+      markdown += `# Question ${questionNumber}: Multiple Choice\n\n`;
+      markdown += `${escapeMarkdown(q.question)}\n\n`;
+      q.choices.forEach((choice) => {
+        const escapedValue = escapeMarkdown(choice.value);
+        markdown += `&nbsp;&nbsp;${choice.key}. ${escapedValue}\n`;
+      });
+      markdown += `\n**Answer:** ${escapeMarkdown(q.answer)}\n`;
+      markdown += `**Explanation:** ${escapeMarkdown(q.explanation)}\n\n`;
+      questionNumber += 1;
+    });
+  }
+
+  // True/False Questions
+  if (response.true_false) {
+    response.true_false.forEach((q) => {
+      markdown += `# Question ${questionNumber}: True/False\n\n`;
+      markdown += `${escapeMarkdown(q.question)}\n\n`;
+      markdown += `**Answer:** ${q.answer ? 'True' : 'False'}\n`;
+      markdown += `**Explanation:** ${escapeMarkdown(q.explanation)}\n\n`;
+      questionNumber += 1;
+    });
+  }
+
+  // Fill in the Blank Questions
+  if (response.fill_in_the_blank) {
+    response.fill_in_the_blank.forEach((q) => {
+      markdown += `# Question ${questionNumber}: Fill in the Blank\n\n`;
+
+      // Format question with blanks
+      let questionText = escapeMarkdown(q.question);
+      q.blanks.forEach((blank) => {
+        questionText = questionText.replace(`{${blank.key}}`, '____');
+      });
+      markdown += `${questionText}\n\n`;
+
+      // Word Bank
+      markdown += '**Word Bank:**\n';
+      markdown += q.word_bank
+        .map((word) => `• ${escapeMarkdown(word)}`)
+        .join('\n');
+      markdown += '\n\n';
+
+      // Answers
+      markdown += '**Answers:**\n';
+      q.blanks.forEach((blank) => {
+        markdown += `${Number(blank.key) + 1}. ${escapeMarkdown(
+          blank.value
+        )}\n`;
+      });
+      markdown += `\n**Explanation:** ${escapeMarkdown(q.explanation)}\n\n`;
+      questionNumber += 1;
+    });
+  }
+
+  return markdown.trim();
+};
+
+const convertSyllabusToMarkdown = (response) => {
+  if (typeof response !== 'object') return '';
+
+  let markdown = '| Section | Details |\n|---------|----------|\n';
+
+  const courseInfo = response.course_information;
+  if (courseInfo) {
+    markdown += `| Course Title | ${escapeMarkdown(
+      courseInfo.course_title
+    )} |\n`;
+    markdown += `| Grade Level | ${escapeMarkdown(courseInfo.grade_level)} |\n`;
+    markdown += `| Description | ${escapeMarkdown(courseInfo.description)} |\n`;
+  }
+
+  const instructorInfo = response.instructor_info;
+  if (instructorInfo) {
+    markdown += `| Instructor Name | ${escapeMarkdown(
+      instructorInfo.name
+    )} |\n`;
+
+    markdown += `| Instructor Title | ${escapeMarkdown(
+      instructorInfo.title
+    )} |\n`;
+  }
+
+  const objectives = response.course_description_objectives?.objectives;
+  if (objectives) {
+    const allObjectives = objectives
+      .map((obj) => `• ${escapeMarkdown(obj)}`)
+      .join('<br>');
+    markdown += `| Objectives | ${allObjectives} |\n`;
+  }
+
+  const outcomes =
+    response.course_description_objectives?.intended_learning_outcomes;
+  if (outcomes) {
+    const allOutcomes = outcomes
+      .map((out) => `• ${escapeMarkdown(out)}`)
+      .join('<br>');
+    markdown += `| Learning Outcomes | ${allOutcomes} |\n`;
+  }
+
+  return markdown;
+};
+
+/**
+ * Converts a tool response to markdown format based on the tool type
+ * @param {Object} response - The response object from the tool
+ * @param {string} toolId - The ID of the tool
+ * @returns {string} - Formatted markdown string
+ */
+export const convertResponseToMarkdown = (response, toolId) => {
+  if (!response) return '';
+
+  switch (toolId) {
+    case TOOLS_ID.MULTIPLE_CHOICE_QUIZ_GENERATOR:
+      return convertQuizToMarkdown(response);
+    case TOOLS_ID.FLASHCARDS_GENERATOR:
+      return convertFlashcardsToMarkdown(response);
+    case TOOLS_ID.WORKSHEET_GENERATOR:
+      return convertWorksheetToMarkdown(response);
+    case TOOLS_ID.SYLLABUS_GENERATOR:
+      return convertSyllabusToMarkdown(response);
+    default:
+      return typeof response === 'string'
+        ? response
+        : JSON.stringify(response, null, 2);
+  }
+};


### PR DESCRIPTION
## Description

- Develop converters for Quiz, Flashcards, Worksheet, and Syllabus tools
- Update Firestore structure to store original JSON and converted Markdown
- Initialize editorState.editHistory with initial version
- Handle edge cases like empty responses and special character escaping
- Ensure no back-conversion from Markdown to JSON
- Integrate converters into the tool generation flow
- Test Markdown generation for all tool types

## Related Issue

https://sharing.clickup.com/9018811771/v/6-901805122349-1/t/h/86er92b3a/231403108364eac

## Type of Change

Please select the type(s) of change that apply and delete those that do not. 

- [x] **New feature**: A non-breaking change that adds functionality.

## Proposed Solution

We implemented converters to transform JSON responses from various tools into Markdown for <DocumentEditor>. Updated Firestore to store both JSON and Markdown, added input validation, and designed the system to be modular for easier maintenance and future extensions.

## How to Test

NA

## Unit Tests

NA

## Documentation Updates

Indicate whether documentation needs to be updated due to this PR. 

- [ ] Yes
- [x] No

If yes, describe what documentation updates are needed and link to the relevant documentation.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Additional Information

 Add any other information that might be useful for the reviewers. 
